### PR TITLE
EXOGTN-2205: Calling logout should be after invalidating the HTTP ses…

### DIFF
--- a/tomcat/tomcat7/src/main/java/org/gatein/wci/tomcat/TC7ServletContainerContext.java
+++ b/tomcat/tomcat7/src/main/java/org/gatein/wci/tomcat/TC7ServletContainerContext.java
@@ -145,7 +145,6 @@ public class TC7ServletContainerContext implements ServletContainerContext, Cont
    public void logout(HttpServletRequest request, HttpServletResponse response) throws ServletException
    {
       HttpSession sess = request.getSession(false);
-      request.logout();
 
       if (sess == null)
          return;
@@ -173,6 +172,7 @@ public class TC7ServletContainerContext implements ServletContainerContext, Cont
          }
 
       }));
+      request.logout();
    }
 
    public String getContainerInfo()


### PR DESCRIPTION
If we call request.logout(), the container will destroy the session without invalidation. The listeners won't be executed and a new session will be assigned to the request that does not hold user conversation state.
The fix makes sure that the session is invalidated before the logout.
